### PR TITLE
:sparkles: Add a method for having multiple APIs within the same inst…

### DIFF
--- a/lib/bubblez.rb
+++ b/lib/bubblez.rb
@@ -9,12 +9,17 @@ require 'json'
 
 module Bubblez
   class Resources < RestClientResources
-    def initialize(api_key='')
+    def initialize(name, api_key='')
       super
 
+      @config = Bubblez.configuration[name]
       @package_name = Bubblez::VersionInformation.package_name
       @version_name = Bubblez::VersionInformation.version_name
       @version_code = Bubblez::VersionInformation.version_code
+    end
+
+    def config
+      @config
     end
 
     def get_version_info

--- a/lib/bubblez/config.rb
+++ b/lib/bubblez/config.rb
@@ -15,14 +15,14 @@ module Bubblez
   #
   # @example In app/config/initializers/bubblez.rb
   #    Bubblez.configure do |config|
-  #      config.endpoints = [
-  #        {
-  #          :type => :get,
-  #          :location => :version,
-  #          :authenticated => false,
-  #          :api_key_required => false
-  #        }
-  #      ]
+  #      config.add_api('someApiName', endpoints: [
+  #            {
+  #              :type => :get,
+  #              :location => :version,
+  #              :authenticated => false,
+  #              :api_key_required => false
+  #            }
+  #          ])
   #    end
   def self.configure
     yield(configuration)
@@ -30,17 +30,67 @@ module Bubblez
 
   def self.configuration
     @configuration ||= Configuration.new
+
+    @configuration
+  end
+
+  class Configuration
+    def initialize
+      @apis = []
+    end
+
+    def num_apis
+      @apis.length
+    end
+
+    def [] (key = nil)
+      if key.nil? && @apis.length == 1
+        return @apis[0]
+      end
+
+      unless @apis.include? key
+        self.add_api(name: key)
+      end
+
+      if key.is_a? Integer and key < @apis.length
+        return @apis[key]
+      end
+
+      if key.is_a? String
+        return @apis.detect {|e| e.name == key}
+      end
+
+      nil
+    end
+
+    def add_api(name: 'Default', environments: nil, endpoints: nil)
+      api_config = ApiConfiguration.new name
+      unless environments == nil
+        api_config.environments = environments
+      end
+
+      unless endpoints == nil
+        api_config.endpoints = endpoints
+      end
+
+      @apis.push(api_config)
+    end
   end
 
   ##
-  # The configuration of the Bubblez rest client.
+  # The configuration of a single API within the Bubblez rest client.
   #
   # Use this class if you want to retrieve configuration values set during initialization.
   #
-  class Configuration
-    def initialize
+  class ApiConfiguration
+    def initialize(name = '')
+      @name = name
       @environments = Hash.new
       @endpoints = Hash.new
+    end
+
+    def name
+      @name
     end
 
     ##

--- a/lib/bubblez/rest_client_resources.rb
+++ b/lib/bubblez/rest_client_resources.rb
@@ -3,8 +3,10 @@ require 'bubblez/rest_environment'
 
 module Bubblez
   class RestClientResources
+    ## @TODO_jwir3: This isn't ideal. We should choose an API using the Resources.new, and then simply be able to
+    #               retrieve environments from there.
     def environment(env_name = nil)
-      Bubblez.configuration.environment(env_name)
+      config.environment(env_name)
     end
 
     ##

--- a/spec/bubblez/config_spec.rb
+++ b/spec/bubblez/config_spec.rb
@@ -3,44 +3,49 @@ require 'bubblez'
 
 describe 'Bubblez Configuration' do
   context '#endpoints' do
-    context 'when we specify an environment with two endpoints' do
+    context 'when we specify an api with a single environment having  two endpoints' do
       before do
         Bubblez.configure do |config|
-          config.environments = [
-            {
-              scheme: 'http',
-              host: '127.0.0.1',
-              port: '9002'
-            }
-          ]
-
-          config.endpoints = [
-            {
-              method: :get,
-              location: 'categories',
-              name: 'get_categories',
-              return_type: :body_as_object,
-              authenticated: false,
-              api_key_required: true,
-              headers: {
-                  'X-RapidAPI-Host': @host
-                }
-            },
-            {
-              method: :post,
-              location: :students,
-              authenticated: true,
-              name: 'create_student',
-              return_type: :body_as_object
-            }
-          ]
+          config.add_api(name: 'BoredApi',
+                        environments: [
+                          {
+                            scheme: 'http',
+                            host: '127.0.0.1',
+                            port: '9002'
+                          }
+                        ],
+                        endpoints: [
+                          {
+                            method: :get,
+                            location: 'categories',
+                            name: 'get_categories',
+                            return_type: :body_as_object,
+                            authenticated: false,
+                            api_key_required: true,
+                            headers: {
+                              'X-RapidAPI-Host': @host
+                            }
+                          },
+                          {
+                            method: :post,
+                            location: :students,
+                            authenticated: true,
+                            name: 'create_student',
+                            return_type: :body_as_object
+                          }
+                        ]
+          )
         end
       end
 
       it 'should return that two endpoints were defined' do
         config = Bubblez.configuration
         expect(config).to_not be_nil
-        expect(config.endpoints.length).to eq(2)
+        expect(config.num_apis).to eq(1)
+
+        boredApi = config['BoredApi']
+        expect(config[0]).to_not be_nil
+        expect(boredApi).to_not be_nil
       end
     end
   end

--- a/spec/bubblez/rest_environment_spec.rb
+++ b/spec/bubblez/rest_environment_spec.rb
@@ -6,7 +6,7 @@ describe Bubblez::RestEnvironment do
     context 'for an environment that specifies a scheme of http and a default port' do
       before do
         Bubblez.configure do |config|
-          config.environments = [{
+          config['Default'].environments = [{
             scheme: 'http',
             host: 'somewhere.something.net',
           }]
@@ -14,7 +14,8 @@ describe Bubblez::RestEnvironment do
       end
 
       it 'should actually set the port to 80' do
-        env = Bubblez::Resources.new.environment
+        resources = Bubblez::Resources.new 'Default'
+        env = resources.environment
         expect(env.port).to eq(80)
       end
     end
@@ -22,7 +23,7 @@ describe Bubblez::RestEnvironment do
     context 'for an environment that specifies a scheme of https and a default port' do
       before do
         Bubblez.configure do |config|
-          config.environments = [{
+          config['Default'].environments = [{
             scheme: 'https',
             host: 'somewhere.something.net',
           }]
@@ -30,7 +31,8 @@ describe Bubblez::RestEnvironment do
       end
 
       it 'should actually set the port to 443' do
-        env = Bubblez::Resources.new.environment
+        resources = Bubblez::Resources.new 'Default'
+        env = resources.environment
         expect(env.port).to eq(443)
       end
     end
@@ -39,7 +41,7 @@ describe Bubblez::RestEnvironment do
   describe 'Bubblez::Configure' do
     before do
       Bubblez.configure do |config|
-        config.endpoints = [
+        config['Default'].endpoints = [
           {
             method: :get,
             location: :students,
@@ -61,7 +63,7 @@ describe Bubblez::RestEnvironment do
           }
         ]
 
-        config.environments = [{
+        config['Default'].environments = [{
           scheme: 'http',
           host: '127.0.0.1',
           port: '1234',
@@ -86,7 +88,7 @@ describe Bubblez::RestEnvironment do
   describe '#environments' do
     before do
       Bubblez.configure do |config|
-        config.environments = [{
+        config['Default'].environments = [{
           scheme: 'https',
           host: '127.0.1.1',
           port: '2222',
@@ -99,7 +101,7 @@ describe Bubblez::RestEnvironment do
       it 'should raise an exception' do
         expect {
           Bubblez.configure do |config|
-            config.environments = [
+            config['Default'].environments = [
               {
                 scheme: 'https',
                 host: '127.0.1.1',
@@ -117,7 +119,7 @@ describe Bubblez::RestEnvironment do
     end
 
     it 'returns an address of https://127.0.1.1:2222' do
-      resources = Bubblez::Resources.new
+      resources = Bubblez::Resources.new 'Default'
       environment = resources.environment 'local'
 
       expect(environment).to_not be_nil
@@ -131,7 +133,7 @@ describe Bubblez::RestEnvironment do
     context 'for an environment that has an API key name specified' do
       before do
         Bubblez.configure do |config|
-          config.environments = [{
+          config['Default'].environments = [{
             scheme: 'https',
             host: '127.0.1.1',
             port: '2222',
@@ -142,7 +144,8 @@ describe Bubblez::RestEnvironment do
       end
 
       it 'should return the name of the API key' do
-        env = Bubblez::Resources.new.environment
+        resources = Bubblez::Resources.new 'Default'
+        env = resources.environment
         expect(env.api_key_name).to eq('X-Something-Key')
       end
     end
@@ -150,7 +153,7 @@ describe Bubblez::RestEnvironment do
     context 'for an environment that does not have an API key name specified' do
       before do
         Bubblez.configure do |config|
-          config.environments = [{
+          config['Default'].environments = [{
             scheme: 'https',
             host: '127.0.1.1',
             port: '2222',
@@ -160,7 +163,8 @@ describe Bubblez::RestEnvironment do
       end
 
       it 'should return "X-API-Key"' do
-        env = Bubblez::Resources.new.environment
+        resources = Bubblez::Resources.new 'Default'
+        env = resources.environment
         expect(env.api_key_name).to eq('X-API-Key')
       end
     end

--- a/spec/fixtures/vcr_cassettes/sinkingmoon_post_login_https.yml
+++ b/spec/fixtures/vcr_cassettes/sinkingmoon_post_login_https.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://127.0.0.1:9002/login
+      body:
+        encoding: UTF-8
+        string: "{}"
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        User-Agent:
+          - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.1p111
+        X-Api-Key:
+          - e5528cb7ee0c5f6cb67af63c8f8111dce91a23e6
+        Authorization:
+          - Basic c2NvdHRqOjEyM3F3ZTQ1Ng==
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '2'
+        Host:
+          - 127.0.0.1:9002
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+        Etag:
+          - W/"e46a1461e99dc9c2db75d7c5827f285e"
+        Cache-Control:
+          - max-age=0, private, must-revalidate
+        X-Request-Id:
+          - aac15e83-cc16-42b6-afa2-ddd1c78cec94
+        X-Runtime:
+          - '0.149320'
+        Transfer-Encoding:
+          - chunked
+      body:
+        encoding: UTF-8
+        string: '{"id":1,"name":"Scott Johnson","username":"scottj","email":"scottj@sinkingmoon.com","validation_hash":null,"validation_expire_date":null,"email_validated":true,"created_at":"2019-04-28T15:30:59.105Z","updated_at":"2019-04-28T15:44:41.909Z","role":"admin","auth_token":"eyJhbGciOiJIUzI1NiJ9.eyJjcmVhdGlvbl9kYXRlIjoiMjAxOS0wNC0yOFQxMDo0NDo0MS0wNTowMCIsImV4cGlyYXRpb25fZGF0ZSI6IjIwMTktMDUtMjhUMTA6NDQ6NDEtMDU6MDAiLCJ1c2VyX2lkIjoxfQ.C1mSYJ7ho6Cly8Ik_BcDzfC6rKb6cheY-NMbXV7QWvE","one_time_login_hash":null,"one_time_login_hash_expire_date":null}'
+      http_version:
+    recorded_at: Sun, 28 Apr 2019 23:01:49 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
…ance.

Bubblez now supports having multiple APIs simultaneously. Prior to this commit, it was only possible to have a single API client (i.e. you wouldn't be able to use a single Bubblez instance/configuration for accessing both Google and Stripe). Now, however, we've switched to named instances of API configurations. This allows us to have as many APIs as we want, as long as each one has a unique name.

Refs #45.